### PR TITLE
fix: remove shapeless rope and nail recipe via new reciperemover mod

### DIFF
--- a/config/reciperemover.json
+++ b/config/reciperemover.json
@@ -1,0 +1,13 @@
+{
+  "inventoryRecipeBookX": 0,
+  "inventoryRecipeBookY": 0,
+  "printErrorMessage": false,
+  "printRecipesAndAdvancements": false,
+  "removeAllVanillaAdvancements": false,
+  "removeAllAdvancements": false,
+  "recipeList": [
+    "comforts:rope_and_nail_shapeless"
+  ],
+  "advancementList": [],
+  "itemList": []
+}


### PR DESCRIPTION
- Added new mod [RecipeRemover](https://modrinth.com/mod/reciperemover/versions?g=1.20.1)
- Added `comforts:rope_and_nail_shapeless` to the removed recipe list

Shaped recipe is still viable, tested in local server/client. 

Related to #6 