### PR TITLE
feat: adjust levelz for spectrum

### DIFF
--- a/world/datapacks/hilistia/data/levelz/mining/spectrum_adjustments.json
+++ b/world/datapacks/hilistia/data/levelz/mining/spectrum_adjustments.json
@@ -1,6 +1,6 @@
 {
     "replace": false,
-    "level": 5,
+    "level": 4,
     "block": [
         "minecraft:amethyst_block",
         "minecraft:budding_amethyst",

--- a/world/datapacks/hilistia/data/levelz/mining/spectrum_adjustments.json
+++ b/world/datapacks/hilistia/data/levelz/mining/spectrum_adjustments.json
@@ -1,0 +1,13 @@
+{
+    "replace": false,
+    "level": 5,
+    "block": [
+        "minecraft:amethyst_block",
+        "minecraft:budding_amethyst",
+        "minecraft:small_amethyst_bud",
+        "minecraft:medium_amethyst_bud",
+        "minecraft:large_amethyst_bud",
+        "minecraft:amethyst_cluster",
+        "minecraft:calcite"
+    ]
+}


### PR DESCRIPTION
- Reduce levelZ mining requirement for all amethyst type blocks to level 4
- Not tracked: Remove enchated mods
- Not tracked: Add spectrum mods